### PR TITLE
Native HubSpot forms in site design + resilient Firebase init

### DIFF
--- a/public/rss.xml
+++ b/public/rss.xml
@@ -9,9 +9,9 @@
             <link>https://www.taxed.ch</link>
         </image>
         <generator>RSS for Node</generator>
-        <lastBuildDate>Thu, 16 Jul 2026 06:56:58 GMT</lastBuildDate>
+        <lastBuildDate>Sun, 12 Jul 2026 17:21:52 GMT</lastBuildDate>
         <atom:link href="https://www.taxed.ch/rss.xml" rel="self" type="application/rss+xml"/>
-        <pubDate>Thu, 16 Jul 2026 06:56:58 GMT</pubDate>
+        <pubDate>Sun, 12 Jul 2026 17:21:52 GMT</pubDate>
         <copyright><![CDATA[© 2026 Taxed GmbH]]></copyright>
         <language><![CDATA[en]]></language>
         <item>

--- a/src/components/forms/HubSpotContactForm.jsx
+++ b/src/components/forms/HubSpotContactForm.jsx
@@ -1,0 +1,160 @@
+import React, { useState } from 'react';
+import { Loader2, CheckCircle, AlertCircle, Send } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { submitHubSpotForm, HUBSPOT_FORMS } from '@/services/hubspotForms';
+
+const inputClasses =
+  'w-full min-h-[44px] px-4 py-2.5 rounded-lg border border-gray-300 bg-white text-dark-gray placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-steel-blue focus:border-steel-blue transition-colors';
+
+const Field = ({ id, label, required, children }) => (
+  <div>
+    <label htmlFor={id} className="block text-sm font-semibold text-gray-700 mb-1.5">
+      {label}
+      {required && <span className="text-brand-red ml-0.5">*</span>}
+    </label>
+    {children}
+  </div>
+);
+
+/**
+ * Native contact/onboarding form submitting to HubSpot.
+ * Mirrors the fields of HubSpot form "contact" (email, name, address, phone, message).
+ */
+const HubSpotContactForm = ({ className }) => {
+  const [values, setValues] = useState({
+    firstname: '',
+    lastname: '',
+    email: '',
+    phone: '',
+    company: '',
+    address: '',
+    zip: '',
+    city: '',
+    message: ''
+  });
+  const [status, setStatus] = useState('idle'); // idle | submitting | success | error
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const handleChange = (e) =>
+    setValues((v) => ({ ...v, [e.target.name]: e.target.value }));
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setStatus('submitting');
+    setErrorMessage('');
+    try {
+      const result = await submitHubSpotForm(HUBSPOT_FORMS.contact, values);
+      if (result.ok) {
+        setStatus('success');
+      } else {
+        setStatus('error');
+        setErrorMessage(result.message || '');
+      }
+    } catch {
+      setStatus('error');
+      setErrorMessage('');
+    }
+  };
+
+  if (status === 'success') {
+    return (
+      <div className={cn('bg-green-50 border border-green-200 rounded-xl p-8 text-center', className)}>
+        <CheckCircle className="h-12 w-12 text-green-600 mx-auto mb-4" />
+        <h3 className="text-xl font-bold text-gray-900 mb-2">Thank you!</h3>
+        <p className="text-gray-600">
+          Your request has been received. We will contact you within one business day to get started.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className={cn('space-y-5', className)} noValidate={false}>
+      <div className="grid sm:grid-cols-2 gap-5">
+        <Field id="hs-firstname" label="First name" required>
+          <input id="hs-firstname" name="firstname" type="text" autoComplete="given-name" required
+            value={values.firstname} onChange={handleChange} className={inputClasses} />
+        </Field>
+        <Field id="hs-lastname" label="Last name" required>
+          <input id="hs-lastname" name="lastname" type="text" autoComplete="family-name" required
+            value={values.lastname} onChange={handleChange} className={inputClasses} />
+        </Field>
+      </div>
+
+      <div className="grid sm:grid-cols-2 gap-5">
+        <Field id="hs-email" label="Email" required>
+          <input id="hs-email" name="email" type="email" autoComplete="email" required
+            value={values.email} onChange={handleChange} className={inputClasses} placeholder="you@example.com" />
+        </Field>
+        <Field id="hs-phone" label="Phone number" required>
+          <input id="hs-phone" name="phone" type="tel" autoComplete="tel" required
+            value={values.phone} onChange={handleChange} className={inputClasses} placeholder="+41 79 000 00 00" />
+        </Field>
+      </div>
+
+      <Field id="hs-company" label="Company name">
+        <input id="hs-company" name="company" type="text" autoComplete="organization"
+          value={values.company} onChange={handleChange} className={inputClasses} placeholder="Optional" />
+      </Field>
+
+      <Field id="hs-address" label="Street address" required>
+        <input id="hs-address" name="address" type="text" autoComplete="street-address" required
+          value={values.address} onChange={handleChange} className={inputClasses} />
+      </Field>
+
+      <div className="grid grid-cols-[1fr_2fr] gap-5">
+        <Field id="hs-zip" label="Postal code" required>
+          <input id="hs-zip" name="zip" type="text" inputMode="numeric" autoComplete="postal-code" required
+            value={values.zip} onChange={handleChange} className={inputClasses} />
+        </Field>
+        <Field id="hs-city" label="Municipality" required>
+          <input id="hs-city" name="city" type="text" autoComplete="address-level2" required
+            value={values.city} onChange={handleChange} className={inputClasses} />
+        </Field>
+      </div>
+
+      <Field id="hs-message" label="Message">
+        <textarea id="hs-message" name="message" rows={4}
+          value={values.message} onChange={handleChange}
+          className={cn(inputClasses, 'resize-y min-h-[110px]')}
+          placeholder="Tell us briefly about your tax situation (optional)" />
+      </Field>
+
+      {status === 'error' && (
+        <div className="flex items-start space-x-3 bg-red-50 border border-red-200 rounded-lg p-4" role="alert">
+          <AlertCircle className="h-5 w-5 text-red-600 mt-0.5 flex-shrink-0" />
+          <p className="text-sm text-red-700">
+            {errorMessage || 'Something went wrong sending your request.'}{' '}
+            Please try again or email us directly at{' '}
+            <a href="mailto:info@taxed.ch" className="font-semibold underline">info@taxed.ch</a>.
+          </p>
+        </div>
+      )}
+
+      <button
+        type="submit"
+        disabled={status === 'submitting'}
+        className="w-full min-h-[48px] bg-steel-blue text-white px-6 py-3 rounded-lg font-semibold hover:bg-steel-blue/90 focus:outline-none focus:ring-2 focus:ring-steel-blue focus:ring-offset-2 transition-colors disabled:opacity-60 disabled:cursor-not-allowed flex items-center justify-center"
+      >
+        {status === 'submitting' ? (
+          <>
+            <Loader2 className="h-5 w-5 mr-2 animate-spin" />
+            Sending…
+          </>
+        ) : (
+          <>
+            <Send className="h-5 w-5 mr-2" />
+            Get My Free Consultation
+          </>
+        )}
+      </button>
+
+      <p className="text-xs text-gray-500 text-center">
+        We only use your details to respond to your request. See our{' '}
+        <a href="/privacy-policy" className="underline hover:text-steel-blue">privacy policy</a>.
+      </p>
+    </form>
+  );
+};
+
+export default HubSpotContactForm;

--- a/src/components/forms/NewsletterSignupForm.jsx
+++ b/src/components/forms/NewsletterSignupForm.jsx
@@ -1,0 +1,103 @@
+import React, { useState } from 'react';
+import { Loader2, CheckCircle, AlertCircle, Mail } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { submitHubSpotForm, HUBSPOT_FORMS } from '@/services/hubspotForms';
+
+/**
+ * Native newsletter signup submitting to HubSpot (single email field).
+ * variant="light" for white/light cards, variant="dark" for dark gradient panels.
+ */
+const NewsletterSignupForm = ({ variant = 'light', className }) => {
+  const dark = variant === 'dark';
+  const [email, setEmail] = useState('');
+  const [status, setStatus] = useState('idle');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setStatus('submitting');
+    try {
+      const result = await submitHubSpotForm(HUBSPOT_FORMS.newsletter, { email });
+      setStatus(result.ok ? 'success' : 'error');
+    } catch {
+      setStatus('error');
+    }
+  };
+
+  if (status === 'success') {
+    return (
+      <div
+        className={cn(
+          'flex items-center justify-center space-x-3 rounded-lg p-4',
+          dark ? 'bg-white/10 text-white' : 'bg-green-50 border border-green-200 text-gray-800',
+          className
+        )}
+        role="status"
+      >
+        <CheckCircle className={cn('h-6 w-6 flex-shrink-0', dark ? 'text-green-300' : 'text-green-600')} />
+        <p className="font-semibold">Thank you for subscribing! Please check your inbox.</p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className={cn('w-full', className)}>
+      <div className="flex flex-col sm:flex-row gap-3">
+        <label htmlFor={`newsletter-email-${variant}`} className="sr-only">
+          Email address
+        </label>
+        <input
+          id={`newsletter-email-${variant}`}
+          type="email"
+          required
+          autoComplete="email"
+          placeholder="Your email address"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className={cn(
+            'flex-1 min-h-[48px] px-4 py-3 rounded-lg focus:outline-none focus:ring-2 transition-colors',
+            dark
+              ? 'bg-white/10 border border-white/30 text-white placeholder-blue-200 focus:ring-white/60'
+              : 'bg-white border border-gray-300 text-dark-gray placeholder-gray-400 focus:ring-steel-blue focus:border-steel-blue'
+          )}
+        />
+        <button
+          type="submit"
+          disabled={status === 'submitting'}
+          className={cn(
+            'min-h-[48px] px-6 py-3 rounded-lg font-semibold transition-colors flex items-center justify-center whitespace-nowrap disabled:opacity-60 disabled:cursor-not-allowed focus:outline-none focus:ring-2',
+            dark
+              ? 'bg-white text-steel-blue hover:bg-blue-50 focus:ring-white/60'
+              : 'bg-steel-blue text-white hover:bg-steel-blue/90 focus:ring-steel-blue'
+          )}
+        >
+          {status === 'submitting' ? (
+            <Loader2 className="h-5 w-5 animate-spin" />
+          ) : (
+            <>
+              <Mail className="h-5 w-5 mr-2" />
+              Subscribe
+            </>
+          )}
+        </button>
+      </div>
+
+      {status === 'error' && (
+        <div
+          className={cn(
+            'mt-3 flex items-center space-x-2 text-sm rounded-lg p-3',
+            dark ? 'bg-red-500/20 text-red-100' : 'bg-red-50 border border-red-200 text-red-700'
+          )}
+          role="alert"
+        >
+          <AlertCircle className="h-4 w-4 flex-shrink-0" />
+          <span>
+            Subscription failed. Please try again or email{' '}
+            <a href="mailto:info@taxed.ch" className="underline font-semibold">info@taxed.ch</a>.
+          </span>
+        </div>
+      )}
+    </form>
+  );
+};
+
+export default NewsletterSignupForm;

--- a/src/components/sections/NewsletterSection.tsx
+++ b/src/components/sections/NewsletterSection.tsx
@@ -4,6 +4,7 @@ import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { 
+import NewsletterSignupForm from '@/components/forms/NewsletterSignupForm';
   Mail, 
   Send, 
   CheckCircle, 
@@ -123,19 +124,7 @@ export const NewsletterSection: React.FC<NewsletterSectionProps> = ({ className 
                   </motion.div>
                 )}
 
-                {/* HubSpot Newsletter Signup Form */}
-                <div className="hubspot-newsletter-container">
-                  <iframe 
-                    src="https://share-eu1.hsforms.com/1uITtAEHOS8OOaBP67HZnYQ2ds4ox"
-                    width="100%"
-                    height="400"
-                    frameBorder="0"
-                    scrolling="no"
-                    title="Taxed GmbH Newsletter Signup"
-                    className="border-0 rounded-lg"
-                    style={{ minHeight: '400px', backgroundColor: 'transparent' }}
-                  />
-                </div>
+                <NewsletterSignupForm variant="dark" />
 
                 <p className="text-sm text-blue-200 mt-4">
                   We respect your privacy. Unsubscribe at any time.

--- a/src/config/firebase.ts
+++ b/src/config/firebase.ts
@@ -1,30 +1,44 @@
 // Firebase Configuration
 import { initializeApp } from 'firebase/app';
-import { getAuth } from 'firebase/auth';
-import { getFirestore } from 'firebase/firestore';
-import { getStorage } from 'firebase/storage';
-import { getFunctions } from 'firebase/functions';
+import { getAuth, type Auth } from 'firebase/auth';
+import { getFirestore, type Firestore } from 'firebase/firestore';
+import { getStorage, type FirebaseStorage } from 'firebase/storage';
+import { getFunctions, type Functions } from 'firebase/functions';
+import type { FirebaseApp } from 'firebase/app';
 
-// Your Firebase configuration
-// Using environment variables from .env file
+// Environment variables override the committed defaults. The web config is
+// public by design (it ships in every served JS bundle); access control is
+// enforced by Firebase security rules, not by hiding these values. The
+// defaults keep CI builds (no .env on the runner) fully functional.
 const firebaseConfig = {
-  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
-  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY || 'AIzaSyDlUxpc-zb-f9rStzwnLbMzbD1mfgnSeu0',
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN || 'taxedgmbh.firebaseapp.com',
   databaseURL: import.meta.env.VITE_FIREBASE_DATABASE_URL,
-  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
-  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
-  appId: import.meta.env.VITE_FIREBASE_APP_ID,
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID || 'taxedgmbh',
+  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET || 'taxedgmbh.firebasestorage.app',
+  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID || '1041568476163',
+  appId: import.meta.env.VITE_FIREBASE_APP_ID || '1:1041568476163:web:4740e7522f72f5568a7236',
   measurementId: import.meta.env.VITE_FIREBASE_MEASUREMENT_ID
 };
 
-// Initialize Firebase
-const app = initializeApp(firebaseConfig);
+// Initialize Firebase defensively: a bad or missing configuration must
+// degrade Firebase-backed features, never blank the whole site.
+let app: FirebaseApp | undefined;
+let auth: Auth | undefined;
+let db: Firestore | undefined;
+let storage: FirebaseStorage | undefined;
+let functions: Functions | undefined;
 
-// Initialize Firebase services
-export const auth = getAuth(app);
-export const db = getFirestore(app);
-export const storage = getStorage(app);
-export const functions = getFunctions(app);
+try {
+  app = initializeApp(firebaseConfig);
+  auth = getAuth(app);
+  db = getFirestore(app);
+  storage = getStorage(app);
+  functions = getFunctions(app);
+} catch (error) {
+  // eslint-disable-next-line no-console
+  console.error('Firebase initialization failed — continuing without Firebase:', error);
+}
 
+export { auth, db, storage, functions };
 export default app;

--- a/src/pages/LandingPage.jsx
+++ b/src/pages/LandingPage.jsx
@@ -40,6 +40,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { websiteSchema } from '@/utils/structuredData';
+import HubSpotContactForm from '@/components/forms/HubSpotContactForm';
 
 const LandingPage = () => {
   // Respect user's motion preferences for accessibility
@@ -513,14 +514,7 @@ const LandingPage = () => {
 
                   {/* HubSpot Form - Right Side */}
                   <div className="lg:col-span-3 bg-white rounded-xl p-4 sm:p-6 shadow-inner">
-                    <iframe
-                      src="https://share-eu1.hsforms.com/1xA0NQrALToW5NH7CkatXWA2ds4ox"
-                      width="100%"
-                      frameBorder="0"
-                      scrolling="auto"
-                      title="Free Tax Assessment Form"
-                      className="border-0 rounded-lg w-full min-h-[1100px] sm:min-h-[950px]"
-                    />
+                    <HubSpotContactForm />
                   </div>
                 </div>
               </div>

--- a/src/pages/blog/BlogPage.jsx
+++ b/src/pages/blog/BlogPage.jsx
@@ -23,6 +23,7 @@ import {
 } from 'lucide-react';
 import ShareButton from '@/components/ui/ShareButton';
 import Breadcrumbs from '@/components/Breadcrumbs';
+import NewsletterSignupForm from '@/components/forms/NewsletterSignupForm';
 
 const BlogPostCard = ({ post, index, featured = false, gridSize = 'normal' }) => {
   const getDifficultyColor = (difficulty) => {
@@ -350,19 +351,7 @@ const BlogPage = () => {
                     <p className="text-sm text-gray-600 mb-4">
                       Get the latest Swiss tax insights delivered to your inbox
                     </p>
-                    {/* HubSpot Newsletter Signup Form */}
-                    <div className="hubspot-newsletter-container">
-                      <iframe 
-                        src="https://share-eu1.hsforms.com/1uITtAEHOS8OOaBP67HZnYQ2ds4ox"
-                        width="100%"
-                        height="250"
-                        frameBorder="0"
-                        scrolling="no"
-                        title="Taxed GmbH Newsletter Signup - Blog"
-                        className="border-0 rounded-lg"
-                        style={{ minHeight: '250px' }}
-                      />
-                    </div>
+                    <NewsletterSignupForm />
                   </CardContent>
                 </Card>
               </div>

--- a/src/pages/content/NewsPage.jsx
+++ b/src/pages/content/NewsPage.jsx
@@ -11,6 +11,7 @@ import {
   getRewrittenNews,
   scheduleDailyNewsUpdate
 } from '@/services/newsService';
+import NewsletterSignupForm from '@/components/forms/NewsletterSignupForm';
 
 // Helper functions (moved outside component for NewsCard access)
 const formatDate = (dateString) => {
@@ -239,18 +240,8 @@ const NewsPage = () => {
               Get the latest Swiss tax news and updates delivered to your inbox
             </p>
             <div className="max-w-2xl mx-auto">
-              {/* HubSpot Newsletter Signup Form */}
-              <div className="hubspot-newsletter-container bg-white/10 backdrop-blur-sm rounded-lg p-6">
-                <iframe 
-                  src="https://share-eu1.hsforms.com/1uITtAEHOS8OOaBP67HZnYQ2ds4ox"
-                  width="100%"
-                  height="300"
-                  frameBorder="0"
-                  scrolling="no"
-                  title="Taxed GmbH Newsletter Signup - News"
-                  className="border-0 rounded-lg"
-                  style={{ minHeight: '300px' }}
-                />
+              <div className="bg-white/10 backdrop-blur-sm rounded-lg p-6">
+                <NewsletterSignupForm variant="dark" />
               </div>
             </div>
           </div>

--- a/src/pages/content/ResourceCenterPage.jsx
+++ b/src/pages/content/ResourceCenterPage.jsx
@@ -22,6 +22,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import NewsletterSignupForm from '@/components/forms/NewsletterSignupForm';
 
 const ResourceCenterPage = () => {
   const [email, setEmail] = useState('');
@@ -328,19 +329,7 @@ const ResourceCenterPage = () => {
                 </p>
               </div>
               
-              {/* HubSpot Newsletter Signup Form */}
-              <div className="hubspot-newsletter-container">
-                <iframe 
-                  src="https://share-eu1.hsforms.com/1uITtAEHOS8OOaBP67HZnYQ2ds4ox"
-                  width="100%"
-                  height="350"
-                  frameBorder="0"
-                  scrolling="no"
-                  title="Taxed GmbH Newsletter Signup - Resources"
-                  className="border-0 rounded-lg"
-                  style={{ minHeight: '350px' }}
-                />
-              </div>
+              <NewsletterSignupForm />
               <div className="text-center mt-4">
                 <Button 
                   onClick={() => {

--- a/src/pages/core/ContactPage.jsx
+++ b/src/pages/core/ContactPage.jsx
@@ -31,6 +31,8 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
 import { useToast } from '@/components/ui/use-toast';
+import HubSpotContactForm from '@/components/forms/HubSpotContactForm';
+import NewsletterSignupForm from '@/components/forms/NewsletterSignupForm';
 
 const ContactPage = () => {
   const { toast } = useToast();
@@ -433,19 +435,7 @@ const ContactPage = () => {
                   </CardDescription>
                 </CardHeader>
                 <CardContent className="p-8">
-                  {/* HubSpot Embedded Form */}
-                  <div className="hubspot-form-container">
-                    <iframe 
-                      src="https://share-eu1.hsforms.com/1xA0NQrALToW5NH7CkatXWA2ds4ox"
-                      width="100%"
-                      height="800"
-                      frameBorder="0"
-                      scrolling="yes"
-                      title="Taxed GmbH Contact Form"
-                      className="border-0 rounded-lg"
-                      style={{ minHeight: '800px' }}
-                    />
-                  </div>
+                  <HubSpotContactForm />
                   
                   {/* Security Notice */}
                   <div className="bg-blue-50 p-4 rounded-lg border border-blue-200 mt-6">
@@ -633,19 +623,7 @@ const ContactPage = () => {
                   </p>
                 </div>
 
-                {/* HubSpot Newsletter Signup Form */}
-                <div className="hubspot-newsletter-container">
-                  <iframe 
-                    src="https://share-eu1.hsforms.com/1uITtAEHOS8OOaBP67HZnYQ2ds4ox"
-                    width="100%"
-                    height="400"
-                    frameBorder="0"
-                    scrolling="no"
-                    title="Taxed GmbH Newsletter Signup - Contact Page"
-                    className="border-0 rounded-lg"
-                    style={{ minHeight: '400px', backgroundColor: 'transparent' }}
-                  />
-                </div>
+                <NewsletterSignupForm variant="dark" />
 
                 <p className="text-sm text-blue-200 mt-4">
                   We respect your privacy. Unsubscribe at any time.

--- a/src/services/hubspotForms.js
+++ b/src/services/hubspotForms.js
@@ -1,0 +1,56 @@
+// Native submission to the HubSpot Forms API (EU data residency).
+// Replaces the hosted share-page iframes so forms render in the site's
+// own design while keeping the same HubSpot CRM pipeline and tracking.
+
+export const HUBSPOT_PORTAL_ID = '144079809';
+
+export const HUBSPOT_FORMS = {
+  contact: 'c40d0d42-b00b-4e85-b934-7ec291ab5758',
+  newsletter: 'b884ed00-41ce-4bc3-8e68-13faec766761'
+};
+
+const getHubspotCookie = () => {
+  const match = document.cookie.match(/(^|;\s*)hubspotutk=([^;]*)/);
+  return match ? match[2] : undefined;
+};
+
+/**
+ * Submit fields to a HubSpot form.
+ * @param {string} formId - HubSpot form GUID
+ * @param {Record<string, string>} fields - field name -> value
+ * @returns {Promise<{ok: boolean, message?: string}>}
+ */
+export const submitHubSpotForm = async (formId, fields) => {
+  const url = `https://api-eu1.hsforms.com/submissions/v3/integration/submit/${HUBSPOT_PORTAL_ID}/${formId}`;
+
+  const context = {
+    pageUri: window.location.href,
+    pageName: document.title
+  };
+  const hutk = getHubspotCookie();
+  if (hutk) context.hutk = hutk;
+
+  const body = {
+    fields: Object.entries(fields)
+      .filter(([, value]) => value !== undefined && value !== null && String(value).trim() !== '')
+      .map(([name, value]) => ({ objectTypeId: '0-1', name, value: String(value).trim() })),
+    context
+  };
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+
+  if (response.ok) {
+    const data = await response.json().catch(() => ({}));
+    return { ok: true, message: data.inlineMessage };
+  }
+
+  const error = await response.json().catch(() => ({}));
+  return {
+    ok: false,
+    message: error?.errors?.map((e) => e.message).join('; ') || `Submission failed (${response.status})`
+  };
+};


### PR DESCRIPTION
## Summary

### Design-integrated HubSpot forms
The contact and newsletter forms were embedded as `share-eu1.hsforms.com` iframes — HubSpot's hosted page with its default styling, impossible to theme from outside the iframe. All seven embeds are replaced with native React components in the site's own design system:

- `HubSpotContactForm` — full onboarding form (name, email, phone, address, message) on the Contact page and Landing page
- `NewsletterSignupForm` — compact email signup with `light`/`dark` variants for the five newsletter placements
- Both submit to the HubSpot Forms API (EU endpoint) for the same portal and forms as before — identical CRM pipeline, including `hubspotutk` tracking, page context, and the forms' configured success messages
- **Verified end-to-end**: a live test submission returned HTTP 200 with the form's inline confirmation (test contact `website-form-test@taxed.ch` can be deleted from HubSpot)

### Firebase resilience (important for CI builds)
Discovered while testing: the app rendered a **blank page** whenever the Firebase config was missing/invalid — which is exactly what CI-built bundles produce, since the runner has no `.env`. Fixed twice over:

- `firebase.ts` now initializes defensively — a bad config degrades Firebase features instead of killing the whole site
- The public web config (already visible in every served bundle by design) ships as committed fallback, so Action-built bundles are fully functional; env vars still override

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cs8828uxQZEtdfx9DS2dQD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cs8828uxQZEtdfx9DS2dQD)_