### PR TITLE
Trigger deploy: HOSTINGER_SSH_KEY is now configured

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Build and Deploy
 on:
   push:
     branches: [main]
-    # Only source changes need a rebuild. The Auto-build commit touches only
+    # Only source changes need a rebuild (deploy via SSH once HOSTINGER_SSH_KEY is set). The Auto-build commit touches only
     # dist/ and generated public files, which are excluded here so it cannot
     # re-trigger this workflow (same loop-guard as eflury.com's deploy).
     paths:


### PR DESCRIPTION
Comment-only change to `deploy.yml` to trigger the Build and Deploy workflow now that the `HOSTINGER_SSH_KEY` secret and the deploy public key in hPanel are in place. On merge, the workflow builds and rsyncs `dist/` to the taxed.ch webroot for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cs8828uxQZEtdfx9DS2dQD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cs8828uxQZEtdfx9DS2dQD)_