### PR TITLE
Remove fabricated review structured data (Google policy risk)

### DIFF
--- a/src/pages/LandingPage.jsx
+++ b/src/pages/LandingPage.jsx
@@ -244,57 +244,6 @@ const LandingPage = () => {
               "https://www.facebook.com/taxedgmbh",
               "https://twitter.com/taxedgmbh"
             ],
-            "aggregateRating": {
-              "@type": "AggregateRating",
-              "ratingValue": "4.9",
-              "reviewCount": "3",
-              "bestRating": "5",
-              "worstRating": "1"
-            },
-            "review": [
-              {
-                "@type": "Review",
-                "author": {
-                  "@type": "Person",
-                  "name": "Sarah Müller"
-                },
-                "reviewRating": {
-                  "@type": "Rating",
-                  "ratingValue": "5",
-                  "bestRating": "5"
-                },
-                "reviewBody": "Taxed GmbH made my Swiss tax filing incredibly simple. The digital process was smooth and their expertise saved me money.",
-                "datePublished": "2024-03-15"
-              },
-              {
-                "@type": "Review",
-                "author": {
-                  "@type": "Person",
-                  "name": "James Wilson"
-                },
-                "reviewRating": {
-                  "@type": "Rating",
-                  "ratingValue": "5",
-                  "bestRating": "5"
-                },
-                "reviewBody": "Professional service with transparent pricing. They handled my complex international income situation perfectly.",
-                "datePublished": "2024-05-22"
-              },
-              {
-                "@type": "Review",
-                "author": {
-                  "@type": "Person",
-                  "name": "Maria Rodriguez"
-                },
-                "reviewRating": {
-                  "@type": "Rating",
-                  "ratingValue": "5",
-                  "bestRating": "5"
-                },
-                "reviewBody": "The client portal is fantastic. I can track everything online and communicate easily with my tax expert.",
-                "datePublished": "2024-07-10"
-              }
-            ],
             "hasOfferCatalog": {
               "@type": "OfferCatalog",
               "name": "Tax Services",

--- a/src/utils/structuredData.js
+++ b/src/utils/structuredData.js
@@ -51,13 +51,6 @@ export const organizationSchema = {
     "name": "Switzerland"
   },
   "priceRange": "CHF 249 - CHF 799",
-  "aggregateRating": {
-    "@type": "AggregateRating",
-    "ratingValue": "4.9",
-    "reviewCount": "127",
-    "bestRating": "5",
-    "worstRating": "1"
-  },
   "hasOfferCatalog": {
     "@type": "OfferCatalog",
     "name": "Tax Services",
@@ -146,50 +139,6 @@ export const websiteSchema = {
     "query-input": "required name=search_term_string"
   }
 };
-
-/**
- * Review Schema Generator
- * Creates individual review structured data
- */
-export const generateReviewSchema = (review) => ({
-  "@type": "Review",
-  "author": {
-    "@type": "Person",
-    "name": review.author
-  },
-  "reviewRating": {
-    "@type": "Rating",
-    "ratingValue": review.rating,
-    "bestRating": "5",
-    "worstRating": "1"
-  },
-  "reviewBody": review.text,
-  "datePublished": review.date
-});
-
-/**
- * Sample Reviews for Homepage
- */
-export const sampleReviews = [
-  {
-    author: "Sarah Müller",
-    rating: "5",
-    text: "Taxed GmbH made my Swiss tax filing incredibly simple. As an American expat, I was overwhelmed by the forms, but they handled everything professionally and got me a CHF 1,200 refund!",
-    date: "2024-03-15"
-  },
-  {
-    author: "James Chen",
-    rating: "5",
-    text: "Best tax service in Switzerland! They understand the complexities of international income and helped me optimize my deductions. Saved me over CHF 3,000.",
-    date: "2024-02-28"
-  },
-  {
-    author: "Maria Rodriguez",
-    rating: "5",
-    text: "Professional, efficient, and affordable. I've been using Taxed GmbH for 3 years and wouldn't trust anyone else with my Swiss taxes.",
-    date: "2024-01-10"
-  }
-];
 
 /**
  * HowTo Schema Generator
@@ -423,8 +372,6 @@ export default {
   organizationSchema,
   websiteSchema,
   localBusinessSchema,
-  sampleReviews,
-  generateReviewSchema,
   generateHowToSchema,
   generateServiceSchema,
   generateFAQSchema,


### PR DESCRIPTION
## Summary

Must-have #2 from the landing-page assessment: the page's JSON-LD declared an `aggregateRating` of 4.9 built from three reviews by invented personas, and a dormant schema in `structuredData.js` claimed **127 reviews**. Self-serving fabricated review markup violates Google's structured-data policies and risks losing rich results or drawing a manual action.

- Removed `aggregateRating` + the fabricated `review` array from the landing page's ProfessionalService schema
- Removed the 127-review `aggregateRating` from `organizationSchema`
- Deleted the unused `sampleReviews` / `generateReviewSchema` fabrication seeds
- Verified the rendered page now emits exactly two JSON-LD blocks (ProfessionalService, WebSite), both valid JSON and review-free

Rating markup can return once it references real, verifiable reviews (e.g. an actual Google Business profile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cs8828uxQZEtdfx9DS2dQD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cs8828uxQZEtdfx9DS2dQD)_