### PR TITLE
Remove dead Clarity snippet + fix silent deploy failure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,15 +71,18 @@ jobs:
           mkdir -p ~/.ssh
           printf '%s\n' "$SSH_KEY" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -p "$SSH_PORT" "$SSH_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+          # keyscan is best-effort; accept-new below covers a keyscan flake
+          # (a failing keyscan under bash -e killed run #7 silently)
+          ssh-keyscan -p "$SSH_PORT" "$SSH_HOST" >> ~/.ssh/known_hosts 2>/dev/null || echo "ssh-keyscan failed - relying on accept-new"
+          SSH_OPTS="-i $HOME/.ssh/deploy_key -p $SSH_PORT -o StrictHostKeyChecking=accept-new -o ConnectTimeout=20"
           echo "Verifying remote deploy path..."
-          ssh -i ~/.ssh/deploy_key -p "$SSH_PORT" "$SSH_USER@$SSH_HOST" "test -d $DEPLOY_PATH" || {
-            echo "::error::Remote path $DEPLOY_PATH not found - listing domains for diagnosis"
-            ssh -i ~/.ssh/deploy_key -p "$SSH_PORT" "$SSH_USER@$SSH_HOST" "ls domains" || true
+          ssh $SSH_OPTS "$SSH_USER@$SSH_HOST" "test -d $DEPLOY_PATH" || {
+            echo "::error::Remote path $DEPLOY_PATH not found or SSH failed - listing domains for diagnosis"
+            ssh $SSH_OPTS "$SSH_USER@$SSH_HOST" "ls domains" || true
             exit 1
           }
           echo "Syncing dist/ to $DEPLOY_PATH ..."
-          rsync -az -e "ssh -i ~/.ssh/deploy_key -p $SSH_PORT" dist/ "$SSH_USER@$SSH_HOST:$DEPLOY_PATH/"
+          rsync -az -e "ssh $SSH_OPTS" dist/ "$SSH_USER@$SSH_HOST:$DEPLOY_PATH/"
           echo "Deployment complete."
 
       - name: Trigger Hostinger webhook (legacy fallback)

--- a/index.html
+++ b/index.html
@@ -73,17 +73,6 @@
       gtag('config', 'G-8QGTP1064K');
     </script>
 
-    <!-- Microsoft Clarity for Bing optimization - Configure with your Clarity Project ID -->
-    <!-- Uncomment and replace CLARITY_PROJECT_ID after setup at https://clarity.microsoft.com -->
-    <!--
-    <script type="text/javascript">
-      (function(c,l,a,r,i,t,y){
-        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-      })(window, document, "clarity", "script", "YOUR_CLARITY_PROJECT_ID");
-    </script>
-    -->
   </head>
   <body>
     <div id="root"></div>

--- a/src/utils/bing.js
+++ b/src/utils/bing.js
@@ -1,9 +1,9 @@
 // Bing Search Engine Optimization Utilities
 
-// Initialize Microsoft Clarity for Bing insights
-export const initializeBingAnalytics = () => {
-  // Clarity is already loaded via the script tag
-};
+// Placeholder for Bing analytics initialization.
+// Microsoft Clarity is not currently installed; the trackBingEvent guard
+// below activates automatically if a Clarity snippet is ever added.
+export const initializeBingAnalytics = () => {};
 
 // Submit URL to Bing for immediate indexing
 export const submitToBingIndexing = async (url) => {


### PR DESCRIPTION
## Summary

**Clarity (must-have #3):** the 404-firing script was only in the old February hand-built page — current builds already ship it commented out, so production stopped 404ing at the first SSH deploy. This removes the dead commented block from `index.html` entirely and corrects the stale "already loaded" comment in `bing.js` (the `window.clarity` guard stays and activates automatically if a real snippet is ever added).

**Deploy robustness:** run #7 (PR #30) failed silently — `ssh-keyscan`'s stderr was discarded and the step runs under `bash -e`, so a transient keyscan failure killed the job before printing anything. Keyscan is now best-effort, with `StrictHostKeyChecking=accept-new` and a connect timeout as the actual safety net. Merging this also re-delivers the PR #30 build (fabricated-review removal) that run #7 failed to sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cs8828uxQZEtdfx9DS2dQD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cs8828uxQZEtdfx9DS2dQD)_