### PR TITLE
Align static HTML language with actual English content

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="de">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -30,9 +30,8 @@
     <link rel="icon" type="image/png" sizes="512x512" href="/favicon-512x512.png" />
     <link rel="manifest" href="/site.webmanifest" />
     <meta name="theme-color" content="#C7242E" />
-    <title>Taxed GmbH - Steuerberatung & Buchhaltung</title>
-    <meta name="description" content="Professionelle Steuerberatung und Buchhaltung für Unternehmen in der Schweiz. Kompetente Beratung für Ihre Steuerangelegenheiten." />
-    <meta name="keywords" content="Steuerberatung, Buchhaltung, Schweiz, Steuern, Unternehmen, Beratung" />
+    <title>Taxed GmbH | Professional Swiss Tax Services for Expats & Businesses</title>
+    <meta name="description" content="Expert Swiss tax consulting for expatriates and businesses. Professional tax returns, Quellensteuer adjustments, and transparent flat-rate pricing." />
     <meta name="author" content="Taxed GmbH" />
     <link rel="canonical" href="https://taxed.ch" />
 
@@ -46,7 +45,7 @@
     <meta property="og:url" content="https://taxed.ch" />
     <meta property="og:image" content="https://taxed.ch/images/og-taxed-logo-square.png" />
     <meta property="og:site_name" content="Taxed GmbH" />
-    <meta property="og:locale" content="de_CH" />
+    <meta property="og:locale" content="en_CH" />
 
     <!-- Twitter/X Cards for better social sharing -->
     <meta name="twitter:card" content="summary_large_image" />


### PR DESCRIPTION
## Summary

Must-have #4 from the landing-page assessment: the static shell declared `lang="de"` with a German title and description while the entire site is English — crawlers, screen readers, and social previews saw the mismatch before React hydrated.

- `<html lang="de">` → `lang="en"`
- Static `<title>`/`<meta description>` now match the English title the landing page sets at runtime (identical pre- and post-hydration metadata)
- `og:locale` `de_CH` → `en_CH`
- Dropped the obsolete German `keywords` meta tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cs8828uxQZEtdfx9DS2dQD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cs8828uxQZEtdfx9DS2dQD)_