### PR TITLE
Lazy-load Firebase + should-have fixes from landing assessment

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,14 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <!-- Preconnect hints for external resources (improves Core Web Vitals) -->
-    <!-- Priority 1: Fonts (render-blocking, 750ms savings) -->
+    <!-- Fonts (render-blocking) -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <!-- Priority 2: Logo/images (LCP impact, 440ms savings) -->
-    <link rel="preconnect" href="https://horizons-cdn.hostinger.com" crossorigin />
-    <!-- Priority 3: HubSpot (330ms savings) -->
-    <link rel="preconnect" href="https://js-eu1.hsforms.net" crossorigin />
-    <!-- Priority 4: Analytics & Firebase -->
+    <!-- Analytics & Firebase -->
     <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
     <link rel="dns-prefetch" href="https://taxedgmbh.firebaseapp.com" />
 
@@ -157,12 +153,18 @@
       <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path d="M16.004 0h-.008C7.174 0 0 7.176 0 16c0 3.5 1.128 6.744 3.046 9.378L1.054 31.29l6.118-1.958A15.908 15.908 0 0016.004 32C24.826 32 32 24.822 32 16S24.826 0 16.004 0zm9.31 22.606c-.39 1.1-1.932 2.014-3.168 2.28-.846.18-1.95.324-5.67-1.218-4.762-1.972-7.828-6.81-8.066-7.124-.228-.314-1.924-2.562-1.924-4.886s1.218-3.468 1.65-3.94c.432-.47.944-.588 1.26-.588.314 0 .63.002.904.016.292.014.682-.11 1.066.814.39.94 1.336 3.264 1.452 3.502.118.236.196.512.04.826-.158.314-.236.512-.472.786-.236.276-.496.616-.708.826-.236.236-.482.492-.208.962.276.472 1.224 2.018 2.63 3.268 1.808 1.608 3.332 2.106 3.804 2.342.472.236.746.196 1.022-.118.276-.314 1.178-1.374 1.492-1.844.314-.472.63-.39 1.06-.236.432.158 2.754 1.298 3.226 1.534.472.236.786.354.904.55.116.196.116 1.14-.274 2.24z"/></svg>
     </a>
     <script>
-      // Show tooltip after 3 seconds, hide after 8 seconds
-      setTimeout(function() {
-        var t = document.getElementById('wa-chat-tooltip');
-        if (t) { t.classList.add('visible'); }
-        setTimeout(function() { if (t) t.classList.remove('visible'); }, 5000);
-      }, 3000);
+      // Auto-show the tooltip once per browser session so it doesn't keep
+      // covering page content on every navigation/reload.
+      try {
+        if (!sessionStorage.getItem('waTooltipShown')) {
+          sessionStorage.setItem('waTooltipShown', '1');
+          setTimeout(function() {
+            var t = document.getElementById('wa-chat-tooltip');
+            if (t) { t.classList.add('visible'); }
+            setTimeout(function() { if (t) t.classList.remove('visible'); }, 5000);
+          }, 3000);
+        }
+      } catch (e) { /* sessionStorage unavailable (private mode) - skip auto-show */ }
       // Show tooltip on hover
       var btn = document.getElementById('wa-chat-btn');
       if (btn) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "vite",
-    "build": "node tools/generate-rss.js && node tools/generate-llms.js && vite build",
+    "build": "node tools/generate-rss.js && node tools/generate-llms.js && node tools/generate-sitemap.js && vite build",
     "preview": "vite preview",
     "test": "playwright test",
     "test:ui": "playwright test --ui",

--- a/public/rss.xml
+++ b/public/rss.xml
@@ -9,9 +9,9 @@
             <link>https://www.taxed.ch</link>
         </image>
         <generator>RSS for Node</generator>
-        <lastBuildDate>Sat, 18 Jul 2026 14:59:46 GMT</lastBuildDate>
+        <lastBuildDate>Sat, 18 Jul 2026 15:04:02 GMT</lastBuildDate>
         <atom:link href="https://www.taxed.ch/rss.xml" rel="self" type="application/rss+xml"/>
-        <pubDate>Sat, 18 Jul 2026 14:59:46 GMT</pubDate>
+        <pubDate>Sat, 18 Jul 2026 15:04:02 GMT</pubDate>
         <copyright><![CDATA[© 2026 Taxed GmbH]]></copyright>
         <language><![CDATA[en]]></language>
         <item>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,280 +1,339 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-        xmlns:news="http://www.google.com/schemas/sitemap-news/0.9"
-        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
-  <!-- Main Pages -->
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://taxed.ch/</loc>
-    <lastmod>2026-02-02</lastmod>
-    <changefreq>daily</changefreq>
+    <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://taxed.ch/about</loc>
-    <lastmod>2026-02-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://taxed.ch/services</loc>
-    <lastmod>2026-02-02</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.95</priority>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://taxed.ch/how-it-works</loc>
-    <lastmod>2026-02-02</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
+    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://taxed.ch/pricing</loc>
-    <lastmod>2026-02-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://taxed.ch/contact</loc>
-    <lastmod>2026-02-02</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
+    <priority>0.9</priority>
   </url>
-
-  <!-- Store -->
   <url>
     <loc>https://taxed.ch/store</loc>
-    <lastmod>2026-02-02</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
-
-  <!-- Client Services -->
   <url>
-    <loc>https://taxed.ch/client-portal</loc>
-    <lastmod>2026-02-02</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://taxed.ch/case-studies</loc>
-    <lastmod>2026-02-02</lastmod>
+    <loc>https://taxed.ch/blog</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://taxed.ch/team</loc>
-    <lastmod>2026-02-02</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://taxed.ch/industry-specializations</loc>
-    <lastmod>2026-02-02</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://taxed.ch/advanced-tax-tools</loc>
-    <lastmod>2026-02-02</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://taxed.ch/testimonials</loc>
-    <lastmod>2026-02-02</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-
-  <!-- Tax Guides -->
-  <url>
-    <loc>https://taxed.ch/tax-deadlines</loc>
-    <lastmod>2026-02-02</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
-    <loc>https://taxed.ch/expat-tax-guide</loc>
-    <lastmod>2026-02-02</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
-    <loc>https://taxed.ch/tax-planning-guide</loc>
-    <lastmod>2026-02-02</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
-    <loc>https://taxed.ch/business-tax-guide</loc>
-    <lastmod>2026-02-02</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://taxed.ch/international-tax</loc>
-    <lastmod>2026-02-02</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://taxed.ch/tax-return-explained</loc>
-    <lastmod>2026-02-02</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-
-  <!-- Tax Services -->
-  <url>
-    <loc>https://taxed.ch/tax-forms</loc>
-    <lastmod>2026-02-02</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://taxed.ch/tax-updates</loc>
-    <lastmod>2026-02-02</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://taxed.ch/webinars</loc>
-    <lastmod>2026-02-02</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://taxed.ch/tax-audit-support</loc>
-    <lastmod>2026-02-02</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://taxed.ch/tax-compliance</loc>
-    <lastmod>2026-02-02</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://taxed.ch/tax-recovery</loc>
-    <lastmod>2026-02-02</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-  </url>
-
-  <!-- Tools & Resources -->
-  <url>
-    <loc>https://taxed.ch/calculators</loc>
-    <lastmod>2026-02-02</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.95</priority>
-  </url>
-  <url>
-    <loc>https://taxed.ch/resources</loc>
-    <lastmod>2026-02-02</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://taxed.ch/law</loc>
-    <lastmod>2026-02-02</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://taxed.ch/technology</loc>
-    <lastmod>2026-02-02</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://taxed.ch/security</loc>
-    <lastmod>2026-02-02</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://taxed.ch/support</loc>
-    <lastmod>2026-02-02</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://taxed.ch/tax-glossary</loc>
-    <lastmod>2026-02-02</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://taxed.ch/events</loc>
-    <lastmod>2026-02-02</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
-  </url>
-
-  <!-- Content & News -->
-  <url>
-    <loc>https://taxed.ch/blog</loc>
-    <lastmod>2026-02-02</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://taxed.ch/news</loc>
-    <lastmod>2026-02-02</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
-  </url>
-
-  <!-- Support & Information -->
-  <url>
-    <loc>https://taxed.ch/faq</loc>
-    <lastmod>2026-02-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://taxed.ch/careers</loc>
-    <lastmod>2026-02-02</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/faq</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/case-studies</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/testimonials</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/industry-specializations</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://taxed.ch/partnership</loc>
-    <lastmod>2026-02-02</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/calculators</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/resources</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/news</loc>
+    <changefreq>daily</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/law</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
-
-  <!-- Legal & Compliance -->
+  <url>
+    <loc>https://taxed.ch/tax-deadlines</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/tax-forms</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/tax-glossary</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/tax-updates</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/technology</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/security</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/support</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/tax-compliance</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/tax-audit-support</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/tax-recovery</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/tax-return-explained</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/tax-planning-guide</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/business-tax-guide</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/expat-tax-guide</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/international-tax</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/advanced-tax-tools</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/events</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/webinars</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/forum</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
   <url>
     <loc>https://taxed.ch/impressum</loc>
-    <lastmod>2026-02-02</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://taxed.ch/privacy-policy</loc>
-    <lastmod>2026-02-02</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.5</priority>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
   </url>
   <url>
     <loc>https://taxed.ch/terms</loc>
-    <lastmod>2026-02-02</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>0.4</priority>
-  </url>
-  <url>
-    <loc>https://taxed.ch/cookies</loc>
-    <lastmod>2026-02-02</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://taxed.ch/accessibility</loc>
-    <lastmod>2026-02-02</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/blog/eigenmietwert-imputed-rental-value-switzerland-complete-guide</loc>
+    <lastmod>2026-02-01</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/blog/swiss-tax-return-guide-2025-complete-step-by-step-tutorial</loc>
+    <lastmod>2025-11-28</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/blog/top-10-tax-deductions-expats-switzerland-2025</loc>
+    <lastmod>2025-11-27</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/blog/swiss-kita-costs-tax-deductions-guide-parents-2025</loc>
+    <lastmod>2025-02-03</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/blog/swiss-agricultural-tariffs-usa-trade-negotiations-2025</loc>
+    <lastmod>2025-02-02</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/blog/switzerland-usa-fatca-agreement-tax-dispute-resolution-2013</loc>
+    <lastmod>2025-02-01</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/blog/swiss-eigenmietwert-referendum-property-tax-changes-2025</loc>
+    <lastmod>2025-01-30</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/blog/retroactive-pillar-3a-contributions-switzerland-2025</loc>
+    <lastmod>2025-01-25</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/blog/tax-deductible-expenses-switzerland-2025-guide-individuals</loc>
+    <lastmod>2025-01-20</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/blog/flexible-retirement-switzerland-tax-implications-2025</loc>
+    <lastmod>2025-01-20</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/blog/swiss-tax-developments-2025-oecd-minimum-tax-implementation</loc>
+    <lastmod>2025-01-20</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/blog/understanding-swiss-tax-at-source-quellensteuer-2025</loc>
+    <lastmod>2025-01-15</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/blog/cryptocurrency-taxation-in-switzerland-2025</loc>
+    <lastmod>2025-01-12</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/blog/expat-guide-to-pillar-3a-pension-in-switzerland-2025</loc>
+    <lastmod>2025-01-10</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/blog/swiss-wealth-tax-complete-guide-2025</loc>
+    <lastmod>2025-01-08</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/blog/navigating-swiss-real-estate-tax-for-expats-2025</loc>
+    <lastmod>2025-01-05</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/blog/expat-tax-planning-strategies-switzerland-2025</loc>
+    <lastmod>2025-01-03</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/blog/swiss-business-tax-guide-for-expats-2025</loc>
+    <lastmod>2025-01-01</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/blog/swiss-inheritance-tax-guide-2025</loc>
+    <lastmod>2024-12-28</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/blog/swiss-health-insurance-tax-deductions-2025</loc>
+    <lastmod>2024-12-25</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://taxed.ch/blog/swiss-education-tax-benefits-expats-2025</loc>
+    <lastmod>2024-12-22</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.6</priority>
   </url>
 </urlset>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -33,7 +33,7 @@ const Footer = () => {
               Ready to Simplify Your Swiss Taxes?
             </h2>
             <p className="text-gray-300 text-lg mb-8 max-w-2xl mx-auto">
-              Join thousands of expats who trust Taxed GmbH for their Swiss tax filing.
+              Join 500+ expats who trust Taxed GmbH for their Swiss tax filing.
               Get started today with our transparent, flat-rate service.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">

--- a/src/components/features/auth/RegisterForm.tsx
+++ b/src/components/features/auth/RegisterForm.tsx
@@ -165,7 +165,7 @@ export const RegisterForm: React.FC<RegisterFormProps> = ({
             Create Your Account
           </h2>
           <p className="text-gray-600">
-            Join thousands of clients who trust us with their tax needs
+            Join 500+ clients who trust us with their tax needs
           </p>
         </motion.div>
 

--- a/src/contexts/ClientAuthContext.tsx
+++ b/src/contexts/ClientAuthContext.tsx
@@ -1,12 +1,5 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
-import {
-  signInWithEmailAndPassword,
-  signOut,
-  onAuthStateChanged,
-  User as FirebaseUser
-} from 'firebase/auth';
-import { doc, getDoc } from 'firebase/firestore';
-import { auth, db } from '../config/firebase';
+import type { User as FirebaseUser } from 'firebase/auth';
 import { User } from '../types/admin';
 
 interface ClientAuthContextType {
@@ -27,58 +20,109 @@ export const useClientAuth = () => {
   return context;
 };
 
+// Firebase is deliberately loaded via dynamic import so the ~113KB (gzip)
+// vendor-firebase chunk stays out of the initial bundle. Public pages render
+// without it; auth restores during browser idle time, and login() pulls it
+// on demand.
+const loadFirebase = async () => {
+  const [{ auth, db }, authMod, firestoreMod] = await Promise.all([
+    import('../config/firebase'),
+    import('firebase/auth'),
+    import('firebase/firestore')
+  ]);
+  return {
+    auth,
+    db,
+    signInWithEmailAndPassword: authMod.signInWithEmailAndPassword,
+    signOut: authMod.signOut,
+    onAuthStateChanged: authMod.onAuthStateChanged,
+    doc: firestoreMod.doc,
+    getDoc: firestoreMod.getDoc
+  };
+};
+
+const scheduleIdle = (callback: () => void): (() => void) => {
+  if (typeof window !== 'undefined' && 'requestIdleCallback' in window) {
+    const id = window.requestIdleCallback(callback, { timeout: 4000 });
+    return () => window.cancelIdleCallback(id);
+  }
+  const id = setTimeout(callback, 2000);
+  return () => clearTimeout(id);
+};
+
 export const ClientAuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [currentUser, setCurrentUser] = useState<User | null>(null);
   const [firebaseUser, setFirebaseUser] = useState<FirebaseUser | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, async (user) => {
-      if (user) {
-        setFirebaseUser(user);
-        // Fetch user data from Firestore
-        try {
-          const userDoc = await getDoc(doc(db, 'users', user.uid));
-          if (userDoc.exists()) {
-            const userData = userDoc.data() as User;
-            // Only allow customers to access the client portal
-            if (userData.role === 'customer') {
-              setCurrentUser({ ...userData, id: user.uid });
-            } else {
-              // Sign out non-customers who try to access the client portal
-              await signOut(auth);
-              setCurrentUser(null);
-              setFirebaseUser(null);
-            }
-          }
-        } catch (error) {
-          console.error('Error fetching user data:', error);
-          setCurrentUser(null);
+    let unsubscribe: (() => void) | undefined;
+    let cancelled = false;
+
+    const cancelIdle = scheduleIdle(async () => {
+      try {
+        const fb = await loadFirebase();
+        if (cancelled || !fb.auth || !fb.db) {
+          setLoading(false);
+          return;
         }
-      } else {
-        setCurrentUser(null);
-        setFirebaseUser(null);
+        unsubscribe = fb.onAuthStateChanged(fb.auth, async (user) => {
+          if (user) {
+            setFirebaseUser(user);
+            try {
+              const userDoc = await fb.getDoc(fb.doc(fb.db!, 'users', user.uid));
+              if (userDoc.exists()) {
+                const userData = userDoc.data() as User;
+                // Only allow customers to access the client portal
+                if (userData.role === 'customer') {
+                  setCurrentUser({ ...userData, id: user.uid });
+                } else {
+                  await fb.signOut(fb.auth!);
+                  setCurrentUser(null);
+                  setFirebaseUser(null);
+                }
+              }
+            } catch (error) {
+              console.error('Error fetching user data:', error);
+              setCurrentUser(null);
+            }
+          } else {
+            setCurrentUser(null);
+            setFirebaseUser(null);
+          }
+          setLoading(false);
+        });
+      } catch (error) {
+        console.error('Deferred Firebase load failed:', error);
+        setLoading(false);
       }
-      setLoading(false);
     });
 
-    return unsubscribe;
+    return () => {
+      cancelled = true;
+      cancelIdle();
+      if (unsubscribe) unsubscribe();
+    };
   }, []);
 
   const login = async (email: string, password: string) => {
+    const fb = await loadFirebase();
+    if (!fb.auth || !fb.db) {
+      throw new Error('Authentication is temporarily unavailable. Please try again.');
+    }
     try {
-      const userCredential = await signInWithEmailAndPassword(auth, email, password);
+      const userCredential = await fb.signInWithEmailAndPassword(fb.auth, email, password);
 
       // Check if user has customer role
-      const userDoc = await getDoc(doc(db, 'users', userCredential.user.uid));
+      const userDoc = await fb.getDoc(fb.doc(fb.db, 'users', userCredential.user.uid));
       if (userDoc.exists()) {
         const userData = userDoc.data() as User;
         if (userData.role !== 'customer') {
-          await signOut(auth);
+          await fb.signOut(fb.auth);
           throw new Error('Access denied. This portal is for customers only. Please use the admin portal if you are an expert or admin.');
         }
       } else {
-        await signOut(auth);
+        await fb.signOut(fb.auth);
         throw new Error('User data not found.');
       }
     } catch (error: any) {
@@ -95,8 +139,10 @@ export const ClientAuthProvider: React.FC<{ children: React.ReactNode }> = ({ ch
   };
 
   const logout = async () => {
+    const fb = await loadFirebase();
+    if (!fb.auth) return;
     try {
-      await signOut(auth);
+      await fb.signOut(fb.auth);
     } catch (error) {
       console.error('Error signing out:', error);
       throw error;

--- a/tools/generate-sitemap.js
+++ b/tools/generate-sitemap.js
@@ -1,0 +1,101 @@
+import fs from 'fs';
+import blogPosts from '../src/data/blogPosts.js';
+
+// Public, indexable routes (mirrors src/App.jsx; excludes admin, portal,
+// cart/checkout, and legal-utility pages we don't want prioritized).
+const BASE = 'https://taxed.ch';
+
+const staticPages = [
+  { path: '/', priority: '1.0', changefreq: 'weekly' },
+  { path: '/about', priority: '0.9', changefreq: 'monthly' },
+  { path: '/services', priority: '0.9', changefreq: 'monthly' },
+  { path: '/how-it-works', priority: '0.9', changefreq: 'monthly' },
+  { path: '/pricing', priority: '0.9', changefreq: 'monthly' },
+  { path: '/contact', priority: '0.9', changefreq: 'monthly' },
+  { path: '/store', priority: '0.8', changefreq: 'weekly' },
+  { path: '/blog', priority: '0.8', changefreq: 'weekly' },
+  { path: '/team', priority: '0.7', changefreq: 'monthly' },
+  { path: '/careers', priority: '0.6', changefreq: 'monthly' },
+  { path: '/faq', priority: '0.7', changefreq: 'monthly' },
+  { path: '/case-studies', priority: '0.7', changefreq: 'monthly' },
+  { path: '/testimonials', priority: '0.6', changefreq: 'monthly' },
+  { path: '/industry-specializations', priority: '0.6', changefreq: 'monthly' },
+  { path: '/partnership', priority: '0.5', changefreq: 'monthly' },
+  { path: '/calculators', priority: '0.8', changefreq: 'monthly' },
+  { path: '/resources', priority: '0.7', changefreq: 'weekly' },
+  { path: '/news', priority: '0.7', changefreq: 'daily' },
+  { path: '/law', priority: '0.6', changefreq: 'monthly' },
+  { path: '/tax-deadlines', priority: '0.8', changefreq: 'monthly' },
+  { path: '/tax-forms', priority: '0.7', changefreq: 'monthly' },
+  { path: '/tax-glossary', priority: '0.6', changefreq: 'monthly' },
+  { path: '/tax-updates', priority: '0.7', changefreq: 'weekly' },
+  { path: '/tax-calculators', skip: true },
+  { path: '/technology', priority: '0.5', changefreq: 'monthly' },
+  { path: '/security', priority: '0.5', changefreq: 'monthly' },
+  { path: '/support', priority: '0.6', changefreq: 'monthly' },
+  { path: '/tax-compliance', priority: '0.6', changefreq: 'monthly' },
+  { path: '/tax-audit-support', priority: '0.6', changefreq: 'monthly' },
+  { path: '/tax-recovery', priority: '0.6', changefreq: 'monthly' },
+  { path: '/tax-return-explained', priority: '0.7', changefreq: 'monthly' },
+  { path: '/tax-planning-guide', priority: '0.7', changefreq: 'monthly' },
+  { path: '/business-tax-guide', priority: '0.7', changefreq: 'monthly' },
+  { path: '/expat-tax-guide', priority: '0.8', changefreq: 'monthly' },
+  { path: '/international-tax', priority: '0.7', changefreq: 'monthly' },
+  { path: '/advanced-tax-tools', priority: '0.6', changefreq: 'monthly' },
+  { path: '/events', priority: '0.5', changefreq: 'monthly' },
+  { path: '/webinars', priority: '0.5', changefreq: 'monthly' },
+  { path: '/forum', priority: '0.5', changefreq: 'weekly' },
+  { path: '/impressum', priority: '0.3', changefreq: 'yearly' },
+  { path: '/privacy-policy', priority: '0.3', changefreq: 'yearly' },
+  { path: '/terms', priority: '0.3', changefreq: 'yearly' },
+  { path: '/accessibility', priority: '0.3', changefreq: 'yearly' }
+].filter((p) => !p.skip);
+
+const escapeXml = (s) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+const urlEntry = ({ loc, lastmod, changefreq, priority }) => `  <url>
+    <loc>${escapeXml(loc)}</loc>${lastmod ? `
+    <lastmod>${lastmod}</lastmod>` : ''}
+    <changefreq>${changefreq}</changefreq>
+    <priority>${priority}</priority>
+  </url>`;
+
+function generateSitemap() {
+  const entries = [];
+
+  // Static pages: no lastmod (a fake per-build date is worse than none)
+  for (const page of staticPages) {
+    entries.push(urlEntry({
+      loc: `${BASE}${page.path}`,
+      changefreq: page.changefreq,
+      priority: page.priority
+    }));
+  }
+
+  // Blog posts: real publication dates, newest first
+  const posts = [...blogPosts].sort((a, b) => new Date(b.date) - new Date(a.date));
+  for (const post of posts) {
+    entries.push(urlEntry({
+      loc: `${BASE}/blog/${post.slug}`,
+      lastmod: post.date,
+      changefreq: 'yearly',
+      priority: post.featured ? '0.7' : '0.6'
+    }));
+  }
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${entries.join('\n')}
+</urlset>
+`;
+
+  fs.writeFileSync('./public/sitemap.xml', xml);
+  console.log(`✅ Sitemap generated: ${staticPages.length} pages + ${posts.length} blog posts`);
+}
+
+try {
+  generateSitemap();
+} catch (error) {
+  console.error('Error generating sitemap:', error);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

The should-have batch from the landing-page assessment:

**Performance — Firebase out of the critical path.** `vendor-firebase` (113KB gzip, ~43% of the route's JS) was statically imported via `ClientAuthContext` and modulepreloaded on every page. The context now dynamic-imports Firebase during browser idle (`requestIdleCallback`, 4s fallback), and `login()`/`logout()` load it on demand. The chunk is gone from the modulepreload list; first paint no longer competes with it. Verified locally: landing renders without it, client-portal login still functions.

**Content/UX**
- "Join thousands" → "Join 500+" (Footer, RegisterForm) — matches the hero stat
- WhatsApp tooltip auto-opens once per session instead of on every page load
- Removed stale preconnects (`js-eu1.hsforms.net` — forms are native now; `horizons-cdn.hostinger.com` — nothing loads from it)

**SEO**
- New `tools/generate-sitemap.js` in the build chain: 42 public routes + 21 blog posts with real publication dates, replacing the hand-maintained sitemap frozen at 2026-02-02

Not included: real testimonial quotes (waiting on actual client quotes from the owner — cannot be invented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cs8828uxQZEtdfx9DS2dQD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cs8828uxQZEtdfx9DS2dQD)_