### PR TITLE
Show branded hero illustration on mobile

### DIFF
--- a/src/pages/LandingPage.jsx
+++ b/src/pages/LandingPage.jsx
@@ -335,7 +335,7 @@ const LandingPage = () => {
             initial={fadeIn.initial}
             animate={fadeIn.animate}
             transition={prefersReducedMotion ? { duration: 0 } : { duration: 1, delay: 0.2 }}
-            className="hidden lg:flex justify-center"
+            className="flex justify-center mt-2 lg:mt-0"
           >
             <img
               src="/images/hero-illustration.svg"
@@ -344,7 +344,7 @@ const LandingPage = () => {
               width="560"
               height="457"
               decoding="async"
-              className="w-full max-w-[560px] h-auto"
+              className="w-full max-w-[340px] sm:max-w-[420px] lg:max-w-[560px] h-auto"
             />
           </motion.div>
           </div>


### PR DESCRIPTION
The new hero artwork was desktop-only (`hidden lg:flex`), so phone visitors never saw it. It now renders on every breakpoint — 340px on phones, 420px on tablets, 560px on desktop — slotted between the CTAs and the stats row in the mobile flow. Verified at 390px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cs8828uxQZEtdfx9DS2dQD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cs8828uxQZEtdfx9DS2dQD)_